### PR TITLE
changed to sign in link when user does not sign in

### DIFF
--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -29,7 +29,7 @@
                   %i.far.fa-thumbs-up
                   #{Like.model_name.human}(<span data-target="like.count">#{comment.likes_count}</span>)
           - else
-            %span.text-muted
+            = link_to login_path, class: "text-muted" do
               %i.far.fa-thumbs-up
               #{Like.model_name.human}(#{comment.likes_count})
       - if destination

--- a/app/views/issues/_issue.html.haml
+++ b/app/views/issues/_issue.html.haml
@@ -29,6 +29,6 @@
                   %i.far.fa-thumbs-up
                   #{Like.model_name.human}(<span data-target="like.count">#{issue.likes_count}</span>)
           - else
-            %span.text-muted
+            = link_to login_path, class: "text-muted" do
               %i.far.fa-thumbs-up
               #{Like.model_name.human}(#{issue.likes_count})


### PR DESCRIPTION
スマートフォンで閲覧した時、like のリンクがログイン状態にかかわらずデザインが一緒なため押せるかどうか判別がしづらいと思いました。
デスクトップの場合はマウスオーバーすればリンクのデザインがつきます。

そこで非ログイン時はGitHubのログイン画面に遷移させるようにしました。

コメントには各コメントへのアンカーリンクをつけてみようと思いましたが、コールバックされるときに無視されるようなので実装しませんでした。

よかったら取り込みをお願いします！

ps, 今回はじめて Rails Developers Meetup 参加しましたが、本当にたのしかったです!
ありがとうございました！